### PR TITLE
Remove WeatherReports/all endpoint

### DIFF
--- a/src/AprsWeatherServer/Controllers/WeatherReportsController.cs
+++ b/src/AprsWeatherServer/Controllers/WeatherReportsController.cs
@@ -20,16 +20,6 @@ public class WeatherReportsController : ControllerBase
     }
 
     /// <summary>
-    /// Gets all <see cref="WeatherReport"/>s held by the server.
-    /// </summary>
-    /// <returns>A list of <see cref="WeatherReport"/>s</returns>
-    [HttpGet(Name = "GetAllWeatherReports")]
-    public IEnumerable<WeatherReport> All()
-    {
-        return reports.Values;
-    }
-
-    /// <summary>
     /// Gets <see cref="WeatherReport"/>s near a given location.
     /// </summary>
     /// <param name="location">Sorts by the proximity to a given location (specified as the centerpoint of a gridsquare).</param>

--- a/test/AprsWeatherServerTests/WeatherReportsControllerTests.cs
+++ b/test/AprsWeatherServerTests/WeatherReportsControllerTests.cs
@@ -20,7 +20,6 @@ public class WeatherReportsControllerTests
 {
     public readonly IDictionary<string, WeatherReport> serverReports = new Dictionary<string, WeatherReport>();
     public readonly HttpClient client;
-    private const string allReportsEndpoint = "WeatherReports/All";
     private const string reportsNearEndpoint = "WeatherReports/Near";
 
     public WeatherReportsControllerTests()
@@ -43,41 +42,6 @@ public class WeatherReportsControllerTests
             });
 
         client = app.CreateClient();
-    }
-
-    /// <summary>
-    /// Verifies all reports are returned
-    /// </summary>
-    [Fact]
-    public async Task TestGetAllReports()
-    {
-        var packet1 = @"N0CALL-1>WIDE2-2:/092345z4903.50N/07201.75W_180/010g015t068r001p011P010h99b09901l010#010s050 Testing WX packet.";
-        var packet2 = @"N0CALL-2>WIDE1-1:/092345z4903.50N/07201.75W_180/010 Testing WX packet #2.";
-        SetServerReports(new[] { packet1, packet2 });
-
-        var response = await GetReports(allReportsEndpoint) ?? throw new Exception("Server response should not be null here");
-
-        Assert.Equal(2, response.Count());
-
-        // Assert all reports are present
-        var reports = response.Select(r => r.Report);
-        Assert.Contains(packet1, reports);
-        Assert.Contains(packet2, reports);
-
-        // Assert times are within the last few minutes
-        Assert.DoesNotContain(response.Select(r => r.ReceivedTime), time => DateTimeOffset.UtcNow - time > TimeSpan.FromMinutes(2));
-    }
-
-    /// <summary>
-    /// Verifies empty list when no reports available
-    /// </summary>
-    [Fact]
-    public async Task TestGetAllReportsEmpty()
-    {
-        SetServerReports();
-
-        var reports = await GetReports(allReportsEndpoint);
-        Assert.Empty(reports);
     }
 
     /// <summary>


### PR DESCRIPTION
Now that the server is tracking some 2.2k reports globally, returning all in a single list is somewhat useless. This PR removes the `/WeatherReports/all` endpoint to avoid it being misused.