### PR TITLE
Validate user input gridsquare

### DIFF
--- a/src/AprsWeatherClient/Pages/Index.razor
+++ b/src/AprsWeatherClient/Pages/Index.razor
@@ -20,12 +20,11 @@
             placeholder="Gridsquare"
             @bind="userGridsquare"
             pattern=@GRIDSQUARE_REGEX
-            title="Maidenhead Gridsquare of lenth 4, 6, or 8"
+            title="Maidenhead Gridsquare of length 4, 6, or 8. e.g. `CN87to`"
         />
+        <input type="button" @onclick="AutoLocation" value="Find My Location"/>
         <input type="submit" @onclick="ManualLocation" value="Get Weather!"/>
     </form>
-    <button @onclick="AutoLocation">Find My Location</button>
-    <br/>
     <a>@userMessage</a>
 </div>
 


### PR DESCRIPTION
Validate user input for gridsquares. The client will now not call the server until a correct gridsquare value is provided. Utilizes html `form` validation (but blocks form submission) to provide tooltips on formatting when submitted. Switch to `form` also means proper return for submit now works.