### PR TITLE
Page through further and closer reports

### DIFF
--- a/src/AprsWeatherClient/Pages/Index.razor
+++ b/src/AprsWeatherClient/Pages/Index.razor
@@ -164,6 +164,9 @@ else
         await ManualLocation();
     }
 
+    /// <summary>
+    /// Pages through reports: previous closer report (unless already on closest)
+    /// </summary>
     private void PreviousReport()
     {
         if (reportIndex > 0)
@@ -172,6 +175,9 @@ else
         }
     }
 
+    /// <summary>
+    /// Pages through reports: next further report. Fetches new reports from the server if necessary.
+    /// </summary>
     private async Task NextReport()
     {
         if (reportIndex + 1 >= reports.Count)
@@ -191,6 +197,11 @@ else
         }
     }
 
+    /// <summary>
+    /// Fetches reports from the server, skipping the provided number of reports.
+    /// </summary>
+    /// <param name="skip">Number of reports to skip for pagination</param>
+    /// <returns>A list of <see cref="WeatherReport"/> from the server response</returns>
     private async Task<IList<WeatherReport>> GetReports(int skip = 0)
     {
         var reports = await client.GetFromJsonAsync<IEnumerable<WeatherReport>>($"{apiAddress}/WeatherReports/Near?location={userGridsquare}&limit=3&skip={skip}");

--- a/src/AprsWeatherClient/Pages/Index.razor
+++ b/src/AprsWeatherClient/Pages/Index.razor
@@ -40,7 +40,7 @@
 {
     <p><em>Input location...</em></p>
 }
-else if (report == null)
+else if (currentReport == null)
 {
     <p><em>Loading...</em></p>
 }
@@ -54,7 +54,7 @@ else
             </tr>
         </thead>
         <tbody>
-            @if (report.Packet.InfoField is WeatherInfo wi)
+            @if (currentReport.Packet.InfoField is WeatherInfo wi)
             {
                 @foreach ((string label, WeatherInfoHelpers.MeasurementDisplayMap displayMap) in WeatherInfoHelpers.PropertyLabels)
                 {
@@ -70,22 +70,28 @@ else
 
                 <div>
                     <i>
-                        Reported <b>@report.ReceivedTime.MinutesSince() minutes ago</b> from about
+                        Reported <b>@currentReport.ReceivedTime.MinutesSince() minutes ago</b> from about
                         <a
                             href=@($"https://www.openstreetmap.org/?mlat={wi.Position.Coordinates.Latitude}&mlon={wi.Position.Coordinates.Longitude}")
                             target="_blank">
                             <b>@($"{userPosition.MilesTo(wi.Position)} miles {userPosition.DirectionTo(wi.Position)}") away</b>
                         </a>
-                        by <b>@report.Packet.Sender</b>.
+                        by <b>@currentReport.Packet.Sender</b>.
                     </i>
                 </div>
             }
         </tbody>
     </table>
+    <span>
+        <button type="button" @onclick="PreviousReport" disabled=@(reportIndex == 0)>Closer Station</button>
+        <button type="button" @onclick="NextReport">Further Station</button>
+    </span>
 }
 
 @code {
-    private WeatherReport? report;
+    private IList<WeatherReport> reports = new List<WeatherReport>();
+    private WeatherReport? currentReport = null;
+    private int reportIndex = 0;
     private HttpClient client = new HttpClient();
     private string? apiAddress;
     private string? userGridsquare;
@@ -97,7 +103,7 @@ else
     /// </summary>
     private const string GRIDSQUARE_REGEX = @"^[a-zA-Z]{2}[0-9]{2}(([a-zA-Z]{2})|([a-zA-Z]{2}[0-9]{2}))?$";
 
-    private async Task UpdateReports()
+    private async Task LoadNewReports()
     {
         if (string.IsNullOrWhiteSpace(userGridsquare))
         {
@@ -109,8 +115,8 @@ else
             apiAddress = Configuration["ServerAddress"];
         }
 
-        var response = await client.GetFromJsonAsync<IEnumerable<WeatherReport>>($"{apiAddress}/WeatherReports/Near?location={userGridsquare}&limit=1");
-        report = response?.SingleOrDefault();
+        reports = await GetReports(0);
+        currentReport = reports.FirstOrDefault();
     }
 
     private async Task ManualLocation()
@@ -130,7 +136,7 @@ else
         userPosition = new Position();
         userPosition.DecodeMaidenhead(userGridsquare);
 
-        await UpdateReports();
+        await LoadNewReports();
     }
 
     private async Task AutoLocation()
@@ -149,7 +155,7 @@ else
         userPosition.Coordinates = new GeoCoordinatePortable.GeoCoordinate(location.Position.Coords.Latitude, location.Position.Coords.Longitude);
         userGridsquare = userPosition.EncodeGridsquare(6, false);
 
-        await UpdateReports();
+        await LoadNewReports();
     }
 
     private async Task SetExampleLocation(ChangeEventArgs args)
@@ -158,8 +164,41 @@ else
         await ManualLocation();
     }
 
+    private void PreviousReport()
+    {
+        if (reportIndex > 0)
+        {
+            currentReport = reports.Count > 0 ? reports[--reportIndex] : null;
+        }
+    }
+
+    private async Task NextReport()
+    {
+        if (reportIndex + 1 >= reports.Count)
+        {
+            var newReports = await GetReports(reports.Count);
+            if (newReports.Count == 0)
+            {
+                userMessage = "No more reports on the server.";
+            }
+
+            reports = reports.Concat(newReports.ExceptBy(reports.Select(r => r.Packet.Sender), r => r.Packet.Sender)).ToList();
+        }
+
+        if (reports.Count > reportIndex + 1)
+        {
+            currentReport = reports[++reportIndex];
+        }
+    }
+
+    private async Task<IList<WeatherReport>> GetReports(int skip = 0)
+    {
+        var reports = await client.GetFromJsonAsync<IEnumerable<WeatherReport>>($"{apiAddress}/WeatherReports/Near?location={userGridsquare}&limit=3&skip={skip}");
+        return reports?.ToList() ?? new List<WeatherReport>();
+    }
+
     protected override async Task OnInitializedAsync()
     {
-        await UpdateReports();
+        await LoadNewReports();
     }
 }

--- a/src/AprsWeatherClient/Pages/Index.razor
+++ b/src/AprsWeatherClient/Pages/Index.razor
@@ -191,6 +191,9 @@ else
             reports = reports.Concat(newReports.ExceptBy(reports.Select(r => r.Packet.Sender), r => r.Packet.Sender)).ToList();
         }
 
+        // Guarded by a condition as the above concat(.exceptby) might not result in more `reports` if the new
+        // reports were previously seen. This could happen if new reports are added closer than the current pagination point.
+        // Might be good to fix in the future. Unlikely, but could be resolved by a page refresh.
         if (reports.Count > reportIndex + 1)
         {
             currentReport = reports[++reportIndex];

--- a/src/AprsWeatherServer/Controllers/WeatherReportsController.cs
+++ b/src/AprsWeatherServer/Controllers/WeatherReportsController.cs
@@ -24,11 +24,13 @@ public class WeatherReportsController : ControllerBase
     /// </summary>
     /// <param name="location">Sorts by the proximity to a given location (specified as the centerpoint of a gridsquare).</param>
     /// <param name="limit">Limits number of reports to the number given, default is 1.</param>
+    /// <param name="skip">Skips ordered reports, used for paging. Default is 0.</param>
     /// <returns><see cref="WeatherReport"/>s filtered and limited as requested.</returns>
     [HttpGet(Name = "GetWeatherReportsNearLocation")]
     public IEnumerable<WeatherReport> Near(
         [FromQuery] string location,
-        [FromQuery] int limit = 1)
+        [FromQuery] int limit = 1,
+        [FromQuery] int skip = 0)
     {
         if (string.IsNullOrEmpty(location))
         {
@@ -44,6 +46,7 @@ public class WeatherReportsController : ControllerBase
 
         return reports.Values
             .OrderBy(r => (r.Packet.InfoField as WeatherInfo)?.Position.Coordinates.GetDistanceTo(locationPosition.Coordinates))
+            .Skip(skip)
             .Take(limit);
     }
 


### PR DESCRIPTION
## Description

Adds the ability in the web UI to page through multiple report stations with addition of closer and further buttons at the bottom.

This is implemented on the backend with a new `skip` parameter on the `/near` endpoint to support pagination.

## Changes

* New `skip` parameter on the `/near` endpoint to support pagination
* Add next and previous buttons on the UI to flip through reports
* Update functional tests for API pagination

## Validation

* Added functional tests for `/near` endpoint pagination
* Manual verification with `docker compose up --build -d`