### PR TITLE
Code cleanliness refactors on index page

### DIFF
--- a/src/AprsWeatherClient/Models/ReportList.cs
+++ b/src/AprsWeatherClient/Models/ReportList.cs
@@ -1,0 +1,116 @@
+using System.Net.Http.Json;
+using AprsWeather.Shared;
+
+namespace AprsWeatherClient.Models;
+
+/// <summary>
+/// A list of <see cref="WeatherReport"/> objects to view.
+/// </summary>
+public class ReportList
+{
+    /// <summary>
+    /// The current report to display.
+    /// </summary>
+    public WeatherReport? CurrentReport { get; private set; } = null;
+
+    /// <summary>
+    /// Indicates if a previous value is available in the list.
+    /// </summary>
+    public bool HasPrevious => reportIndex > 0;
+
+    /// <summary>
+    /// The list of <see cref="WeatherReport"/>s to view.
+    /// </summary>
+    private IList<WeatherReport> reports = new List<WeatherReport>();
+
+    /// <summary>
+    /// The index of the current report in the <see cref="reports"/> list.
+    /// </summary>
+    private int reportIndex = 0;
+
+    /// <summary>
+    /// <see cref="HttpClient"/> used to populate the list.
+    /// </summary>
+    private readonly HttpClient client;
+
+    /// <summary>
+    /// Gridsquare for queries to the server.
+    /// </summary>
+    private string? gridsquare = null;
+
+    /// <summary>
+    /// Constructs a new <see cref="ReportList"/>
+    /// </summary>
+    /// <param name="client"><see cref="HttpClient"/> to communicate with server.</param>
+    public ReportList(HttpClient client)
+    {
+        this.client = client;
+    }
+
+    /// <summary>
+    /// Sets a new location and repopulates the list on that location.
+    /// </summary>
+    /// <param name="gridsquare">A maidenhead gridsquare position</param>
+    /// <returns>The asynchronous task.</returns>
+    public async Task SetLocation(string gridsquare)
+    {
+        this.gridsquare = gridsquare ?? throw new ArgumentNullException(nameof(gridsquare));
+        reports = await GetReports(0);
+        CurrentReport = reports.FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Pages through reports: previous closer report (unless already on closest)
+    /// </summary>
+    public void Previous()
+    {
+        if (reportIndex > 0)
+        {
+            CurrentReport = reports.Count > 0 ? reports[--reportIndex] : null;
+        }
+    }
+
+    /// <summary>
+    /// Pages through reports: next further report. Fetches new reports from the server if necessary.
+    /// </summary>
+    public async Task<bool> Next()
+    {
+        if (string.IsNullOrWhiteSpace(gridsquare))
+        {
+            return false;
+        }
+
+        if (reportIndex + 1 >= reports.Count)
+        {
+            var newReports = await GetReports(reports.Count);
+            if (newReports.Count == 0)
+            {
+                return false;
+            }
+
+            reports = reports.Concat(newReports.ExceptBy(reports.Select(r => r.Packet.Sender), r => r.Packet.Sender)).ToList();
+        }
+
+        // Guarded by a condition as the above concat(.exceptby) might not result in more `reports` if the new
+        // reports were previously seen. This could happen if new reports are added closer than the current pagination point.
+        // Might be good to fix in the future. Unlikely, but could be resolved by a page refresh.
+        if (reports.Count > reportIndex + 1)
+        {
+            CurrentReport = reports[++reportIndex];
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Fetches reports from the server, skipping the provided number of reports.
+    /// </summary>
+    /// <param name="skip">Number of reports to skip for pagination</param>
+    /// <returns>A list of <see cref="WeatherReport"/> from the server response</returns>
+    private async Task<IList<WeatherReport>> GetReports(int skip = 0)
+    {
+        var reports = await client.GetFromJsonAsync<IEnumerable<WeatherReport>>($"/WeatherReports/Near?location={gridsquare}&limit=3&skip={skip}");
+        return reports?.ToList() ?? new List<WeatherReport>();
+    }
+}

--- a/src/AprsWeatherClient/Models/ReportList.cs
+++ b/src/AprsWeatherClient/Models/ReportList.cs
@@ -92,7 +92,7 @@ public class ReportList
         }
 
         // Guarded by a condition as the above concat(.exceptby) might not result in more `reports` if the new
-        // reports were previously seen. This could happen if new reports are added closer than the current pagination point.
+        // reports were previously seen. This could happen if new reports are received closer than the current pagination point.
         // Might be good to fix in the future. Unlikely, but could be resolved by a page refresh.
         if (reports.Count > reportIndex + 1)
         {

--- a/src/AprsWeatherClient/Pages/Index.razor
+++ b/src/AprsWeatherClient/Pages/Index.razor
@@ -1,13 +1,12 @@
 ﻿@page "/"
 @using AprsSharp.Parsers.Aprs
 @using AprsWeather.Shared
-@using Microsoft.Extensions.Configuration
 @using AprsWeatherClient.Extensions
-@using System.Collections.Generic
+@using AprsWeatherClient.Models
 @using System.Text.RegularExpressions
 @using Darnton.Blazor.DeviceInterop.Geolocation
-@inject IConfiguration Configuration
 @inject IGeolocationService locationService
+@inject ReportList reportList
 
 <PageTitle>APRS Weather</PageTitle>
 
@@ -40,7 +39,7 @@
 {
     <p><em>Input location...</em></p>
 }
-else if (currentReport == null)
+else if (reportList.CurrentReport == null)
 {
     <p><em>Loading...</em></p>
 }
@@ -54,7 +53,7 @@ else
             </tr>
         </thead>
         <tbody>
-            @if (currentReport.Packet.InfoField is WeatherInfo wi)
+            @if (reportList.CurrentReport.Packet.InfoField is WeatherInfo wi)
             {
                 @foreach ((string label, WeatherInfoHelpers.MeasurementDisplayMap displayMap) in WeatherInfoHelpers.PropertyLabels)
                 {
@@ -70,30 +69,26 @@ else
 
                 <div>
                     <i>
-                        Reported <b>@currentReport.ReceivedTime.MinutesSince() minutes ago</b> from about
+                        Reported <b>@reportList.CurrentReport.ReceivedTime.MinutesSince() minutes ago</b> from about
                         <a
                             href=@($"https://www.openstreetmap.org/?mlat={wi.Position.Coordinates.Latitude}&mlon={wi.Position.Coordinates.Longitude}")
                             target="_blank">
                             <b>@($"{userPosition.MilesTo(wi.Position)} miles {userPosition.DirectionTo(wi.Position)}") away</b>
                         </a>
-                        by <b>@currentReport.Packet.Sender</b>.
+                        by <b>@reportList.CurrentReport.Packet.Sender</b>.
                     </i>
                 </div>
             }
         </tbody>
     </table>
     <span>
-        <button type="button" @onclick="PreviousReport" disabled=@(reportIndex == 0)>Closer Station</button>
-        <button type="button" @onclick="NextReport">Further Station</button>
+        <button type="button" @onclick="reportList.Previous" disabled=@(!reportList.HasPrevious)>Closer Station</button>
+        <button type="button" @onclick="reportList.Next">Further Station</button>
     </span>
 }
 
 @code {
-    private IList<WeatherReport> reports = new List<WeatherReport>();
-    private WeatherReport? currentReport = null;
-    private int reportIndex = 0;
-    private HttpClient client = new HttpClient();
-    private string? apiAddress;
+
     private string? userGridsquare;
     private Position? userPosition;
     private string userMessage = string.Empty;
@@ -103,46 +98,42 @@ else
     /// </summary>
     private const string GRIDSQUARE_REGEX = @"^[a-zA-Z]{2}[0-9]{2}(([a-zA-Z]{2})|([a-zA-Z]{2}[0-9]{2}))?$";
 
-    private async Task LoadNewReports()
+    /// <summary>
+    /// Sets the location using a value from the examples dropdown.
+    /// </summary>
+    /// <param name="args">Event change args</param>
+    /// <returns>The asynchronous task</returns>
+    private Task SetExampleLocation(ChangeEventArgs args)
     {
-        if (string.IsNullOrWhiteSpace(userGridsquare))
-        {
-            return;
-        }
-
-        if (apiAddress == null)
-        {
-            apiAddress = Configuration["ServerAddress"];
-        }
-
-        reports = await GetReports(0);
-        currentReport = reports.FirstOrDefault();
+        userGridsquare = args.Value as string ?? throw new Exception("HTML select object did not have value");
+        return ManualLocation();
     }
 
-    private async Task ManualLocation()
+    /// <summary>
+    /// Sets the location using a manual entry value.
+    /// </summary>
+    /// <returns>The asynchronous task</returns>
+    private Task ManualLocation()
     {
-        userMessage = string.Empty;
-
-        if (string.IsNullOrWhiteSpace(userGridsquare))
+        if (!Regex.IsMatch(userGridsquare ?? string.Empty, GRIDSQUARE_REGEX))
         {
-            return;
-        }
-
-        if (!Regex.IsMatch(userGridsquare, GRIDSQUARE_REGEX))
-        {
-            return;
+            return Task.CompletedTask;
         }
 
         userPosition = new Position();
-        userPosition.DecodeMaidenhead(userGridsquare);
 
-        await LoadNewReports();
+        // Null checked above in the regex match.
+        userPosition.DecodeMaidenhead(userGridsquare!);
+
+        return LoadNewReports();
     }
 
+    /// <summary>
+    /// Sets the location using the geolocation API.
+    /// </summary>
+    /// <returns>The asynchronous task</returns>
     private async Task AutoLocation()
     {
-        userMessage = string.Empty;
-
         GeolocationResult location = await locationService.GetCurrentPosition();
 
         if (!location.IsSuccess)
@@ -158,61 +149,26 @@ else
         await LoadNewReports();
     }
 
-    private async Task SetExampleLocation(ChangeEventArgs args)
-    {
-        userGridsquare = args.Value as string ?? throw new Exception("HTML select object did not have value");
-        await ManualLocation();
-    }
-
     /// <summary>
-    /// Pages through reports: previous closer report (unless already on closest)
+    /// Loads new reports using the current value of <see cref="userGridsquare"/>
     /// </summary>
-    private void PreviousReport()
+    /// <returns>The asynchronous task</returns>
+    private Task LoadNewReports()
     {
-        if (reportIndex > 0)
+        if (!Regex.IsMatch(userGridsquare ?? string.Empty, GRIDSQUARE_REGEX))
         {
-            currentReport = reports.Count > 0 ? reports[--reportIndex] : null;
-        }
-    }
-
-    /// <summary>
-    /// Pages through reports: next further report. Fetches new reports from the server if necessary.
-    /// </summary>
-    private async Task NextReport()
-    {
-        if (reportIndex + 1 >= reports.Count)
-        {
-            var newReports = await GetReports(reports.Count);
-            if (newReports.Count == 0)
-            {
-                userMessage = "No more reports on the server.";
-            }
-
-            reports = reports.Concat(newReports.ExceptBy(reports.Select(r => r.Packet.Sender), r => r.Packet.Sender)).ToList();
+            return Task.CompletedTask;
         }
 
-        // Guarded by a condition as the above concat(.exceptby) might not result in more `reports` if the new
-        // reports were previously seen. This could happen if new reports are added closer than the current pagination point.
-        // Might be good to fix in the future. Unlikely, but could be resolved by a page refresh.
-        if (reports.Count > reportIndex + 1)
-        {
-            currentReport = reports[++reportIndex];
-        }
+        userMessage = string.Empty;
+
+        // Null checked above in the regex match.
+        return reportList.SetLocation(userGridsquare!);
     }
 
-    /// <summary>
-    /// Fetches reports from the server, skipping the provided number of reports.
-    /// </summary>
-    /// <param name="skip">Number of reports to skip for pagination</param>
-    /// <returns>A list of <see cref="WeatherReport"/> from the server response</returns>
-    private async Task<IList<WeatherReport>> GetReports(int skip = 0)
+    /// <inheritdoc/>
+    protected override Task OnInitializedAsync()
     {
-        var reports = await client.GetFromJsonAsync<IEnumerable<WeatherReport>>($"{apiAddress}/WeatherReports/Near?location={userGridsquare}&limit=3&skip={skip}");
-        return reports?.ToList() ?? new List<WeatherReport>();
-    }
-
-    protected override async Task OnInitializedAsync()
-    {
-        await LoadNewReports();
+        return LoadNewReports();
     }
 }

--- a/src/AprsWeatherClient/Pages/Index.razor
+++ b/src/AprsWeatherClient/Pages/Index.razor
@@ -1,12 +1,8 @@
 ﻿@page "/"
-@using AprsSharp.Parsers.Aprs
 @using AprsWeather.Shared
+@using AprsSharp.Parsers.Aprs
 @using AprsWeatherClient.Extensions
 @using AprsWeatherClient.Models
-@using System.Text.RegularExpressions
-@using Darnton.Blazor.DeviceInterop.Geolocation
-@inject IGeolocationService locationService
-@inject ReportList reportList
 
 <PageTitle>APRS Weather</PageTitle>
 
@@ -39,7 +35,7 @@
 {
     <p><em>Input location...</em></p>
 }
-else if (reportList.CurrentReport == null)
+else if (ReportList.CurrentReport == null)
 {
     <p><em>Loading...</em></p>
 }
@@ -53,7 +49,7 @@ else
             </tr>
         </thead>
         <tbody>
-            @if (reportList.CurrentReport.Packet.InfoField is WeatherInfo wi)
+            @if (ReportList.CurrentReport.Packet.InfoField is WeatherInfo wi)
             {
                 @foreach ((string label, WeatherInfoHelpers.MeasurementDisplayMap displayMap) in WeatherInfoHelpers.PropertyLabels)
                 {
@@ -69,106 +65,20 @@ else
 
                 <div>
                     <i>
-                        Reported <b>@reportList.CurrentReport.ReceivedTime.MinutesSince() minutes ago</b> from about
+                        Reported <b>@ReportList.CurrentReport.ReceivedTime.MinutesSince() minutes ago</b> from about
                         <a
                             href=@($"https://www.openstreetmap.org/?mlat={wi.Position.Coordinates.Latitude}&mlon={wi.Position.Coordinates.Longitude}")
                             target="_blank">
                             <b>@($"{userPosition.MilesTo(wi.Position)} miles {userPosition.DirectionTo(wi.Position)}") away</b>
                         </a>
-                        by <b>@reportList.CurrentReport.Packet.Sender</b>.
+                        by <b>@ReportList.CurrentReport.Packet.Sender</b>.
                     </i>
                 </div>
             }
         </tbody>
     </table>
     <span>
-        <button type="button" @onclick="reportList.Previous" disabled=@(!reportList.HasPrevious)>Closer Station</button>
-        <button type="button" @onclick="reportList.Next">Further Station</button>
+        <button type="button" @onclick="ReportList.Previous" disabled=@(!ReportList.HasPrevious)>Closer Station</button>
+        <button type="button" @onclick="ReportList.Next">Further Station</button>
     </span>
-}
-
-@code {
-
-    private string? userGridsquare;
-    private Position? userPosition;
-    private string userMessage = string.Empty;
-
-    /// <summary>
-    /// Case-insensitive gridsquare of length 4, 6, or 8
-    /// </summary>
-    private const string GRIDSQUARE_REGEX = @"^[a-zA-Z]{2}[0-9]{2}(([a-zA-Z]{2})|([a-zA-Z]{2}[0-9]{2}))?$";
-
-    /// <summary>
-    /// Sets the location using a value from the examples dropdown.
-    /// </summary>
-    /// <param name="args">Event change args</param>
-    /// <returns>The asynchronous task</returns>
-    private Task SetExampleLocation(ChangeEventArgs args)
-    {
-        userGridsquare = args.Value as string ?? throw new Exception("HTML select object did not have value");
-        return ManualLocation();
-    }
-
-    /// <summary>
-    /// Sets the location using a manual entry value.
-    /// </summary>
-    /// <returns>The asynchronous task</returns>
-    private Task ManualLocation()
-    {
-        if (!Regex.IsMatch(userGridsquare ?? string.Empty, GRIDSQUARE_REGEX))
-        {
-            return Task.CompletedTask;
-        }
-
-        userPosition = new Position();
-
-        // Null checked above in the regex match.
-        userPosition.DecodeMaidenhead(userGridsquare!);
-
-        return LoadNewReports();
-    }
-
-    /// <summary>
-    /// Sets the location using the geolocation API.
-    /// </summary>
-    /// <returns>The asynchronous task</returns>
-    private async Task AutoLocation()
-    {
-        GeolocationResult location = await locationService.GetCurrentPosition();
-
-        if (!location.IsSuccess)
-        {
-            userMessage = "Unable to retrieve user location.";
-            return;
-        }
-
-        userPosition = new Position();
-        userPosition.Coordinates = new GeoCoordinatePortable.GeoCoordinate(location.Position.Coords.Latitude, location.Position.Coords.Longitude);
-        userGridsquare = userPosition.EncodeGridsquare(6, false);
-
-        await LoadNewReports();
-    }
-
-    /// <summary>
-    /// Loads new reports using the current value of <see cref="userGridsquare"/>
-    /// </summary>
-    /// <returns>The asynchronous task</returns>
-    private Task LoadNewReports()
-    {
-        if (!Regex.IsMatch(userGridsquare ?? string.Empty, GRIDSQUARE_REGEX))
-        {
-            return Task.CompletedTask;
-        }
-
-        userMessage = string.Empty;
-
-        // Null checked above in the regex match.
-        return reportList.SetLocation(userGridsquare!);
-    }
-
-    /// <inheritdoc/>
-    protected override Task OnInitializedAsync()
-    {
-        return LoadNewReports();
-    }
 }

--- a/src/AprsWeatherClient/Pages/Index.razor.cs
+++ b/src/AprsWeatherClient/Pages/Index.razor.cs
@@ -1,0 +1,116 @@
+using System.Text.RegularExpressions;
+using AprsSharp.Parsers.Aprs;
+using AprsWeatherClient.Models;
+using Darnton.Blazor.DeviceInterop.Geolocation;
+using Microsoft.AspNetCore.Components;
+
+namespace AprsWeatherClient.Pages;
+
+public partial class Index : ComponentBase
+{
+    /// <summary>
+    /// The value of the location textbox
+    /// </summary>
+    private string? userGridsquare;
+
+    /// <summary>
+    /// The saved position of the user for calculating distances
+    /// </summary>
+    private Position? userPosition;
+
+    /// <summary>
+    /// Output to user in case of errors
+    /// </summary>
+    private string userMessage = string.Empty;
+
+    /// <summary>
+    /// Case-insensitive gridsquare of length 4, 6, or 8
+    /// </summary>
+    private const string GRIDSQUARE_REGEX = @"^[a-zA-Z]{2}[0-9]{2}(([a-zA-Z]{2})|([a-zA-Z]{2}[0-9]{2}))?$";
+
+    /// <summary>
+    /// Location service to query user device location
+    /// </summary>
+    [Inject]
+    public IGeolocationService LocationService { get; set; } = default!;
+
+    /// <summary>
+    /// The object to manage <see cref="WeatherReport"/>s and fetching from the server
+    /// </summary>
+    [Inject]
+    public ReportList ReportList { get; set; } = default!;
+
+    /// <summary>
+    /// Sets the location using a value from the examples dropdown.
+    /// </summary>
+    /// <param name="args">Event change args</param>
+    /// <returns>The asynchronous task</returns>
+    private Task SetExampleLocation(ChangeEventArgs args)
+    {
+        userGridsquare = args.Value as string ?? throw new Exception("HTML select object did not have value");
+        return ManualLocation();
+    }
+
+    /// <summary>
+    /// Sets the location using a manual entry value.
+    /// </summary>
+    /// <returns>The asynchronous task</returns>
+    private Task ManualLocation()
+    {
+        if (!Regex.IsMatch(userGridsquare ?? string.Empty, GRIDSQUARE_REGEX))
+        {
+            return Task.CompletedTask;
+        }
+
+        userPosition = new Position();
+
+        // Null checked above in the regex match.
+        userPosition.DecodeMaidenhead(userGridsquare!);
+
+        return LoadNewReports();
+    }
+
+    /// <summary>
+    /// Sets the location using the geolocation API.
+    /// </summary>
+    /// <returns>The asynchronous task</returns>
+    private async Task AutoLocation()
+    {
+        GeolocationResult location = await LocationService.GetCurrentPosition();
+
+        if (!location.IsSuccess)
+        {
+            userMessage = "Unable to retrieve user location.";
+            return;
+        }
+
+        userPosition = new Position();
+        userPosition.Coordinates = new GeoCoordinatePortable.GeoCoordinate(location.Position.Coords.Latitude, location.Position.Coords.Longitude);
+        userGridsquare = userPosition.EncodeGridsquare(6, false);
+
+        await LoadNewReports();
+    }
+
+    /// <summary>
+    /// Loads new reports using the current value of <see cref="userGridsquare"/>
+    /// </summary>
+    /// <returns>The asynchronous task</returns>
+    private async Task LoadNewReports()
+    {
+        if (!Regex.IsMatch(userGridsquare ?? string.Empty, GRIDSQUARE_REGEX))
+        {
+            return;
+        }
+
+        userMessage = string.Empty;
+
+        // Null checked above in the regex match.
+        await ReportList.SetLocation(userGridsquare!);
+    }
+
+    /// <inheritdoc/>
+    protected override Task OnInitializedAsync()
+    {
+        return LoadNewReports();
+    }
+}

--- a/src/AprsWeatherClient/Program.cs
+++ b/src/AprsWeatherClient/Program.cs
@@ -2,12 +2,17 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using AprsWeatherClient;
 using Darnton.Blazor.DeviceInterop.Geolocation;
+using AprsWeatherClient.Models;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
-builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+var serverAddress = builder.Configuration["ServerAddress"];
+ArgumentNullException.ThrowIfNull(serverAddress);
+
+builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(serverAddress) });
 builder.Services.AddScoped<IGeolocationService, GeolocationService>();
+builder.Services.AddScoped<ReportList>();
 
 await builder.Build().RunAsync();


### PR DESCRIPTION
## Description

Refactors the index page to separate much of the code out of the razor page itself by:
* Refactoring report list management logic in to new `ReportList.cs` file and object
* Switching to split `index.razor`/`index.razor.cs` codebehind style to move C# logic code out of razor view code

## Verification

* Tests pass
* local docker run with manual testing