### PR TITLE
Update paths to handle HttpClient.BaseAddress requirements

### DIFF
--- a/src/AprsWeatherClient/Models/ReportList.cs
+++ b/src/AprsWeatherClient/Models/ReportList.cs
@@ -110,7 +110,7 @@ public class ReportList
     /// <returns>A list of <see cref="WeatherReport"/> from the server response</returns>
     private async Task<IList<WeatherReport>> GetReports(int skip = 0)
     {
-        var reports = await client.GetFromJsonAsync<IEnumerable<WeatherReport>>($"/WeatherReports/Near?location={gridsquare}&limit=3&skip={skip}");
+        var reports = await client.GetFromJsonAsync<IEnumerable<WeatherReport>>($"WeatherReports/Near?location={gridsquare}&limit=3&skip={skip}");
         return reports?.ToList() ?? new List<WeatherReport>();
     }
 }

--- a/src/AprsWeatherClient/wwwroot/appsettings.Development.json
+++ b/src/AprsWeatherClient/wwwroot/appsettings.Development.json
@@ -1,3 +1,3 @@
 {
-    "ServerAddress": "http://localhost:5148"
+    "ServerAddress": "http://localhost:5148/"
 }

--- a/src/AprsWeatherClient/wwwroot/appsettings.json
+++ b/src/AprsWeatherClient/wwwroot/appsettings.json
@@ -1,3 +1,3 @@
 {
-    "ServerAddress": "https://hamwx.bielstein.dev/api"
+    "ServerAddress": "https://hamwx.bielstein.dev/api/"
 }


### PR DESCRIPTION
## Description

`HttpClient.BaseAddress` apparently has very specific requirements around where the `/`s go. View more details at [this StackOverflow discussion](https://stackoverflow.com/questions/23438416/why-is-httpclient-baseaddress-not-working).

Change #33 caused an outage that this should fix.