### PR TITLE
Enable local execution without docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,20 @@ Deployed at: [hamwx.bielstein.dev](https://hamwx.bielstein.dev)
 Before running, you'll have to set a value for the `APRS_IS_CALLSIGN` environment variable.
 This value will be used for APRS-IS login.
 
+### Docker Compose
+
 The full application can be run locally using `docker compose up -d --build`.
 Once that is complete, load `http://localhost:80` in your browser or use `http://localhost:5148/WeatherReports` to test the backend.
 
 Once finished, it can be shut down with `docker compose down`.
+
+### Local/Debug
+
+To run without docker containers, which is helpful for debugging or quickly iterating on UI changes, run the following steps:
+
+1. Find and replace `%ENVIRONMENT%` with `Development` in [src/AprsWeatherClient/wwwroot/index.html](src/AprsWeatherClient/wwwroot/index.html). This uses the [development appsettings](src/AprsWeatherClient/wwwroot/appsettings.Development.json) file when running the client. Careful not to commit this change in git.
+2. Launch the frontend and backend by opening a terminal for each the server and client, changing to each directory (i.e. `src/AprsWeatherClient` and `src/AprsWeatherServer`), and executing `dotnet run` or `dotnet watch`, as desired.
+3. Point your browser to `http://localhost:5184/`
 
 ## Deploying
 

--- a/src/AprsWeatherClient/Properties/launchSettings.json
+++ b/src/AprsWeatherClient/Properties/launchSettings.json
@@ -13,7 +13,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
-      "applicationUrl": "https://localhost:7000;http://localhost:5184",
+      "applicationUrl": "https://localhost:7001;http://localhost:5184",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/AprsWeatherServer/Program.cs
+++ b/src/AprsWeatherServer/Program.cs
@@ -1,8 +1,6 @@
 using AprsWeather.Shared;
 using AprsWeatherServer.BackgroundServices;
 
-var devCorsName = "DevelopmentCorsPolicy";
-
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -11,13 +9,6 @@ builder.Services.AddSingleton<IDictionary<string, WeatherReport>>(
 
 builder.Services.AddHostedService<AprsIsReceiver>();
 builder.Services.AddHostedService<ReportExpiry>();
-
-builder.Services.AddCors(options =>
-{
-    options.AddPolicy(
-        name: devCorsName,
-        b => b.AllowAnyHeader().AllowAnyMethod().AllowAnyOrigin());
-});
 
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
@@ -31,17 +22,12 @@ if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
     app.UseSwaggerUI();
+    app.UseCors(b => b.AllowAnyHeader().AllowAnyMethod().AllowAnyOrigin());
 }
-
-app.UseHttpsRedirection();
-
-// Disable CORS in development
-if (app.Environment.IsDevelopment())
+else
 {
-    app.UseCors(devCorsName);
+    app.UseHttpsRedirection();
 }
-
-app.UseAuthorization();
 
 app.MapControllers();
 


### PR DESCRIPTION
## Description

Some local tweaks to run without docker compose. This enables things like debugging, `dotnet watch`, and faster UI iteration without a full docker rebuild.

## Changes

* Disable HTTPS redirection in development mode
* Document steps to run locally without using docker images
* Change the port in HTTP mode for the client when using `dotnet run` so that both client and server can run together. Since the client is hosted in production as a static resource in Digital Ocean, this should have no production impact