### PR TITLE
Update Actions to use higher node version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,14 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: DotnetVersion
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.x'
-          
+          dotnet-quality: 'ga'
+
       - name: Restore
         run: dotnet restore
 
@@ -59,7 +60,7 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install doctl
         uses: digitalocean/action-doctl@v2


### PR DESCRIPTION
## Description

Some actions workflows such as [this one](https://github.com/CBielstein/AprsWeather/actions/runs/4220796087) are reporting warnings for upcoming update to Node runtime version requirements for actions themselves.

![image](https://user-images.githubusercontent.com/3268813/220040742-4d4bf2c3-9ffd-4707-aa27-dea61913f4fe.png)

This PR bumps up to the highest version of each impacted action to resolve the warning. In this change, we move from setup-dotnet v1 to v3. Although v2 would have sufficed to fix this issue, I'm making the decision to move ahead to the highest version while making a change now to aim to stay up to date and in support.

Resolves #18 

## Changes

* Updates `actions/checkout` from v2 to v3
* Updates `actions/setup-dotnet` from v1 to v3

## Verification

* All changed actions will run as part of this PR and no warnings were displayed