### PR TITLE
Fix bug that allowed back button after re-loading weather reports

### DIFF
--- a/src/AprsWeatherClient/Models/ReportList.cs
+++ b/src/AprsWeatherClient/Models/ReportList.cs
@@ -55,6 +55,7 @@ public class ReportList
     public async Task SetLocation(string gridsquare)
     {
         this.gridsquare = gridsquare ?? throw new ArgumentNullException(nameof(gridsquare));
+        reportIndex = 0;
         reports = await GetReports(0);
         CurrentReport = reports.FirstOrDefault();
     }


### PR DESCRIPTION
## Description

This PR fixes a bug where the `reportIndex` was no reset to zero when the `reports` list was reset following a call to `SetLocation` (updating or refreshing location). This means the index could be higher than the count of the reports list and that could result in an exception or odd behavior when:
* the "previous" button is pressed, as the index will decrement and may still be higher than the end of the array when getting the new report (out of bounds exception)
* the "next" button is pushed, potentially causing additional reports to load and the closest few reports to be skipped to catch the list size up to the index

This change simply resets the `reportIndex` to 0 each time the list is reset to ensure none of those scenarios happen.

## Changes

* Reset `reportIndex` to zero to put report iteration at start of list when list is reset

## Verification

* Manually verified with local run and manual testing
* All tests pass