### PR TITLE
Display station comment

### DIFF
--- a/src/AprsWeatherClient/AprsWeatherClient.csproj
+++ b/src/AprsWeatherClient/AprsWeatherClient.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AprsSharp.AprsParser" Version="0.2.1" />
+    <PackageReference Include="AprsSharp.AprsParser" Version="0.2.2" />
     <PackageReference Include="Darnton.Blazor.DeviceInterop" Version="0.1.2" />
     <PackageReference Include="Geolocation" Version="1.2.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.2" />

--- a/src/AprsWeatherClient/Pages/Index.razor
+++ b/src/AprsWeatherClient/Pages/Index.razor
@@ -72,6 +72,10 @@ else
                             <b>@($"{userPosition.MilesTo(wi.Position)} miles {userPosition.DirectionTo(wi.Position)}") away</b>
                         </a>
                         by <b>@ReportList.CurrentReport.Packet.Sender</b>.
+                        @if(!string.IsNullOrWhiteSpace(wi.Comment))
+                        {
+                            <span><br/>Station comment: @wi.Comment</span>
+                        }
                     </i>
                 </div>
             }


### PR DESCRIPTION
## Description

Takes advantage of a change by @martelro in [AprsSharp](https://github.com/CBielstein/AprsSharp) to display a simplified station comment, if available.

## Changes

* Update AprsSharp from 0.2.1 to 0.2.2 to consume the new functionality (that package is still using pre-release versioning, so this is a feature update, not a bug fix)
* Add a conditional statement on the index page to display the comment if it is available and not empty or null

## Validation

* Tests pass
* Manually verified using local execution both with and without dockerized images