### PR TITLE
Add Plausible Analytics for page view metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Once that is complete, load `http://localhost:80` in your browser or use `http:/
 
 Once finished, it can be shut down with `docker compose down`.
 
+**Note**: If running the client docker container directly, please add `--build-arg ENVIRONMENT=Development` to avoid including page view analytics code.
+
 ### Local/Debug
 
 To run without docker containers, which is helpful for debugging or quickly iterating on UI changes, run the following steps:
@@ -39,3 +41,9 @@ Good resources for finding and viewing APRS reports and gridsquare locations (go
 * [Google Maps APRS (APRS.fi)](https://aprs.fi)
 * [Amateur Radio Ham Radio Maidenhead Grid Square Locator Map](https://www.levinecentral.com/ham/grid_square.php)
 * [GridMapper by QRZ Ham Radio](https://www.qrz.com/gridmapper)
+
+## Analytics Reporting
+
+Visitor analytics reporting is handled by [Plausible.io](https://plausible.io).
+A script is added during deployment to report analytics data to them.
+When forking this repository, please remove or update [src/AprsWeatherClient/deploy/analytics.sh](src/AprsWeatherClient/deploy/analytics.sh).

--- a/src/AprsWeatherClient/Dockerfile
+++ b/src/AprsWeatherClient/Dockerfile
@@ -14,7 +14,8 @@ COPY AprsWeatherShared/ AprsWeatherShared/
 # Build
 COPY . .
 RUN sed -i "s/%ENVIRONMENT%/$ENVIRONMENT/g" AprsWeatherClient/wwwroot/index.html
-RUN ./AprsWeatherClient/deploy/analytics.sh $ENVIRONMENT
+RUN dos2unix AprsWeatherClient/deploy/analytics.sh
+RUN AprsWeatherClient/deploy/analytics.sh $ENVIRONMENT
 RUN dotnet build AprsWeatherClient/AprsWeatherClient.csproj --configuration Release --no-restore
 
 # Publish

--- a/src/AprsWeatherClient/Dockerfile
+++ b/src/AprsWeatherClient/Dockerfile
@@ -15,6 +15,7 @@ COPY AprsWeatherShared/ AprsWeatherShared/
 COPY . .
 RUN sed -i "s/%ENVIRONMENT%/$ENVIRONMENT/g" AprsWeatherClient/wwwroot/index.html
 RUN dos2unix AprsWeatherClient/deploy/analytics.sh
+RUN chmod a+rwx AprsWeatherClient/deploy/analytics.sh
 RUN AprsWeatherClient/deploy/analytics.sh $ENVIRONMENT
 RUN dotnet build AprsWeatherClient/AprsWeatherClient.csproj --configuration Release --no-restore
 

--- a/src/AprsWeatherClient/Dockerfile
+++ b/src/AprsWeatherClient/Dockerfile
@@ -14,6 +14,7 @@ COPY AprsWeatherShared/ AprsWeatherShared/
 # Build
 COPY . .
 RUN sed -i "s/%ENVIRONMENT%/$ENVIRONMENT/g" AprsWeatherClient/wwwroot/index.html
+RUN ./AprsWeatherClient/deploy/analytics.sh $ENVIRONMENT
 RUN dotnet build AprsWeatherClient/AprsWeatherClient.csproj --configuration Release --no-restore
 
 # Publish

--- a/src/AprsWeatherClient/deploy/analytics.sh
+++ b/src/AprsWeatherClient/deploy/analytics.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+if [ $1 == "Production" ];
+then
+    sed -i 's|<!--INSERT: Plausible Analytics scripts-->|<script defer data-domain="hamwx.bielstein.dev" src="https://plausible.io/js/script.js"></script>|' AprsWeatherClient/wwwroot/index.html
+fi

--- a/src/AprsWeatherClient/wwwroot/index.html
+++ b/src/AprsWeatherClient/wwwroot/index.html
@@ -9,6 +9,7 @@
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
     <link href="css/app.css" rel="stylesheet" />
     <link href="AprsWeatherClient.styles.css" rel="stylesheet" />
+    <!--INSERT: Plausible Analytics scripts-->
 </head>
 
 <body>


### PR DESCRIPTION
## Description

This PR configures [Plausible.io](https://plausible.io) Analytics for page view metrics. This is only added during production deployment to avoid development activity mixing in with production activity.

## Changes

* Add plausible.io script in HTML via a placeholder and replacement script in the build
* Add documentation

## Validation

* Ran docker builds locally and observed expected behavior on each (i.e. production includes the script tag, others don't)
* Ran `dotnet run` in client directory and observed script tag was not included (correct for development task)
* Will validate data is flowing once this is deployed