### PR TITLE
Move DigitalOcean app spec validation to separate workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,17 +40,6 @@ jobs:
       - name: Build server docker image
         run: docker build src --file src/AprsWeatherServer/Dockerfile
 
-      - name: Install doctl
-        uses: digitalocean/action-doctl@v2
-        with:
-          token: ${{ secrets.DO_ACCESS_TOKEN }}
-
-      - name: Set environment variables in app spec
-        run: sed -i "s/%APRS_IS_CALLSIGN%/${{ secrets.APRS_IS_CALLSIGN }}/g" .do/app.yaml
-
-      - name: Validate app spec
-        run: doctl apps spec validate .do/app.yaml
-
   deploy:
     name: deploy
     timeout-minutes: 15

--- a/.github/workflows/validate_spec.yml
+++ b/.github/workflows/validate_spec.yml
@@ -1,0 +1,37 @@
+name: validate spec
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.do/app.yaml'
+      - '.github/workflows/validate_spec.yml'
+
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.do/app.yaml'
+      - '.github/workflows/validate_spec.yml'
+
+jobs:
+  validate_spec:
+    name: validate spec
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v3
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DO_ACCESS_TOKEN }}
+
+      - name: Set environment variables in app spec
+        run: sed -i "s/%APRS_IS_CALLSIGN%/${{ secrets.APRS_IS_CALLSIGN }}/g" .do/app.yaml
+
+      - name: Validate app spec
+        run: doctl apps spec validate .do/app.yaml


### PR DESCRIPTION
## Description

Breaks the DIgitalOcean app spec validation out of the main build Action workflow. This allows PRs from forks to run without failing to access secrets. This resolves #43.

I left the validate logic in the deploy step of the build workflow so that the spec is validated again immediately before a deployment is attempted.

## Changes

* Creates new validate spec workflow file
* Moves doctl login and spec validation from build job to new workflow

## Validation

* New and modified workflows will run as part of this PR and after merge
