### PR TITLE
Simplify location input

### DIFF
--- a/src/AprsWeatherClient/Pages/Index.razor
+++ b/src/AprsWeatherClient/Pages/Index.razor
@@ -9,80 +9,101 @@
 <h1>Current Weather</h1>
 
 <div>
-    <form onsubmit="return false;">
-        <input
-            id="userGridsquareBox"
-            placeholder="Gridsquare"
-            @bind="userGridsquare"
-            pattern=@GRIDSQUARE_REGEX
-            title="Maidenhead Gridsquare of length 4, 6, or 8. e.g. `CN87to`"
-        />
-        <input type="button" @onclick="AutoLocation" value="Find My Location"/>
-        <input type="submit" @onclick="ManualLocation" value="Get Weather!"/>
-    </form>
-    <select id="places" @onchange="SetExampleLocation">
-        <option value="none" selected hidden>Example Locations</option>
-        <option value="CN87">Seattle, USA</option>
-        <option value="PM95">Tokyo, Japan</option>
-        <option value="JF96">Cape Town, South Africa</option>
-        <option value="GG87">Rio de Janiero, Brazil</option>
-        <option value="JN18">Paris, France</option>
-    </select>
+    <span>
+        <input type="button" @onclick="UseAutoLocation" value="Use My Location"/>
+        <input type="button" @onclick="UseManualLocation" value="Input Custom Location"/>
+        <input type="button" @onclick="UseExampleLocation" value="Input Custom Location"/>
+
+    </span>
+    @switch (locationType)
+    {
+        case LocationType.Manual:
+            <div>
+                <form onsubmit="return false;">
+                    <input
+                        id="userGridsquareBox"
+                        placeholder="Gridsquare"
+                        @bind="userGridsquare"
+                        pattern=@GRIDSQUARE_REGEX
+                        title="Maidenhead Gridsquare of length 4, 6, or 8. e.g. `CN87to`"
+                    />
+                    <input type="submit" @onclick="SubmitManualLocation" value="Get Weather!"/>
+                </form>
+            </div>
+            break;
+
+        case LocationType.Example:
+            <div>
+                <select id="places" @onchange="SetExampleLocation">
+                    <option value="none" selected hidden>Example Locations</option>
+                    <option value="CN87">Seattle, USA</option>
+                    <option value="PM95">Tokyo, Japan</option>
+                    <option value="JF96">Cape Town, South Africa</option>
+                    <option value="GG87">Rio de Janiero, Brazil</option>
+                    <option value="JN18">Paris, France</option>
+                </select>
+            </div>
+            break;
+
+        case LocationType.Device:
+        default:
+            break;
+    }
+
     <a>@userMessage</a>
 </div>
 
-@if (userGridsquare == null)
+@if (userGridsquare != null)
 {
-    <p><em>Input location...</em></p>
-}
-else if (ReportList.CurrentReport == null)
-{
-    <p><em>Loading...</em></p>
-}
-else
-{
-    <table class="table">
-        <thead>
-            <tr>
-                <th>Measurement</th>
-                <th>Reading</th>
-            </tr>
-        </thead>
-        <tbody>
-            @if (ReportList.CurrentReport.Packet.InfoField is WeatherInfo wi)
-            {
-                @foreach ((string label, WeatherInfoHelpers.MeasurementDisplayMap displayMap) in WeatherInfoHelpers.PropertyLabels)
+    if (ReportList.CurrentReport == null)
+    {
+        <p><em>Loading...</em></p>
+    }
+    else
+    {
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Measurement</th>
+                    <th>Reading</th>
+                </tr>
+            </thead>
+            <tbody>
+                @if (ReportList.CurrentReport.Packet.InfoField is WeatherInfo wi)
                 {
-                    string? measurement = displayMap(wi);
-                    if (measurement != null)
+                    @foreach ((string label, WeatherInfoHelpers.MeasurementDisplayMap displayMap) in WeatherInfoHelpers.PropertyLabels)
                     {
-                        <tr>
-                            <td>@label</td>
-                            <td>@measurement</td>
-                        </tr>
-                    }
-                }
-
-                <div>
-                    <i>
-                        Reported <b>@ReportList.CurrentReport.ReceivedTime.MinutesSince() minutes ago</b> from about
-                        <a
-                            href=@($"https://www.openstreetmap.org/?mlat={wi.Position.Coordinates.Latitude}&mlon={wi.Position.Coordinates.Longitude}")
-                            target="_blank">
-                            <b>@($"{userPosition.MilesTo(wi.Position)} miles {userPosition.DirectionTo(wi.Position)}") away</b>
-                        </a>
-                        by <b>@ReportList.CurrentReport.Packet.Sender</b>.
-                        @if(!string.IsNullOrWhiteSpace(wi.Comment))
+                        string? measurement = displayMap(wi);
+                        if (measurement != null)
                         {
-                            <span><br/>Station comment: @wi.Comment</span>
+                            <tr>
+                                <td>@label</td>
+                                <td>@measurement</td>
+                            </tr>
                         }
-                    </i>
-                </div>
-            }
-        </tbody>
-    </table>
-    <span>
-        <button type="button" @onclick="ReportList.Previous" disabled=@(!ReportList.HasPrevious)>Closer Station</button>
-        <button type="button" @onclick="ReportList.Next">Further Station</button>
-    </span>
+                    }
+
+                    <div>
+                        <i>
+                            Reported <b>@ReportList.CurrentReport.ReceivedTime.MinutesSince() minutes ago</b> from about
+                            <a
+                                href=@($"https://www.openstreetmap.org/?mlat={wi.Position.Coordinates.Latitude}&mlon={wi.Position.Coordinates.Longitude}")
+                                target="_blank">
+                                <b>@($"{userPosition.MilesTo(wi.Position)} miles {userPosition.DirectionTo(wi.Position)}") away</b>
+                            </a>
+                            by <b>@ReportList.CurrentReport.Packet.Sender</b>.
+                            @if(!string.IsNullOrWhiteSpace(wi.Comment))
+                            {
+                                <span><br/>Station comment: @wi.Comment</span>
+                            }
+                        </i>
+                    </div>
+                }
+            </tbody>
+        </table>
+        <span>
+            <button type="button" @onclick="ReportList.Previous" disabled=@(!ReportList.HasPrevious)>Closer Station</button>
+            <button type="button" @onclick="ReportList.Next">Further Station</button>
+        </span>
+    }
 }

--- a/src/AprsWeatherClient/Pages/Index.razor
+++ b/src/AprsWeatherClient/Pages/Index.razor
@@ -11,8 +11,8 @@
 <div>
     <span>
         <input type="button" @onclick="UseAutoLocation" value="Use My Location"/>
-        <input type="button" @onclick="UseManualLocation" value="Input Custom Location"/>
-        <input type="button" @onclick="UseExampleLocation" value="Input Custom Location"/>
+        <input type="button" @onclick="UseManualLocation" value="Input Gridsquare"/>
+        <input type="button" @onclick="UseExampleLocation" value="Example Locations"/>
 
     </span>
     @switch (locationType)

--- a/src/AprsWeatherClient/Pages/Index.razor
+++ b/src/AprsWeatherClient/Pages/Index.razor
@@ -64,7 +64,7 @@
 {
     if (ReportList.CurrentReport == null)
     {
-        <p><em>Loading...</em></p>
+        <p><em>Loading reports...</em></p>
     }
     else
     {

--- a/src/AprsWeatherClient/Pages/Index.razor
+++ b/src/AprsWeatherClient/Pages/Index.razor
@@ -29,7 +29,7 @@
                     />
                     <input type="submit" @onclick="SubmitManualLocation" value="Get Weather!"/>
                 </form>
-                <div>@userMessage</div>
+                <div class="userMessage">@userMessage</div>
             </div>
             break;
 
@@ -43,7 +43,7 @@
                     <option value="GG87">Rio de Janiero, Brazil</option>
                     <option value="JN18">Paris, France</option>
                 </select>
-                <div>@userMessage</div>
+                <div class="userMessage">@userMessage</div>
             </div>
             break;
 
@@ -52,7 +52,7 @@
             @if (!string.IsNullOrWhiteSpace(userMessage))
             {
                 <div class="locationInput">
-                    <div>@userMessage</div>
+                    <div class="userMessage">@userMessage</div>
                 </div>
             }
             break;

--- a/src/AprsWeatherClient/Pages/Index.razor
+++ b/src/AprsWeatherClient/Pages/Index.razor
@@ -13,8 +13,8 @@
         <input type="button" @onclick="UseAutoLocation" value="Use My Location"/>
         <input type="button" @onclick="UseManualLocation" value="Input Gridsquare"/>
         <input type="button" @onclick="UseExampleLocation" value="Example Locations"/>
-
     </span>
+
     @switch (locationType)
     {
         case LocationType.Manual:
@@ -29,6 +29,7 @@
                     />
                     <input type="submit" @onclick="SubmitManualLocation" value="Get Weather!"/>
                 </form>
+                <div>@userMessage</div>
             </div>
             break;
 
@@ -42,15 +43,21 @@
                     <option value="GG87">Rio de Janiero, Brazil</option>
                     <option value="JN18">Paris, France</option>
                 </select>
+                <div>@userMessage</div>
             </div>
             break;
 
         case LocationType.Device:
         default:
+            @if (!string.IsNullOrWhiteSpace(userMessage))
+            {
+                <div class="locationInput">
+                    <div>@userMessage</div>
+                </div>
+            }
             break;
     }
 
-    <a>@userMessage</a>
 </div>
 
 @if (userGridsquare != null)

--- a/src/AprsWeatherClient/Pages/Index.razor
+++ b/src/AprsWeatherClient/Pages/Index.razor
@@ -18,7 +18,7 @@
     @switch (locationType)
     {
         case LocationType.Manual:
-            <div>
+            <div class="locationInput">
                 <form onsubmit="return false;">
                     <input
                         id="userGridsquareBox"
@@ -33,7 +33,7 @@
             break;
 
         case LocationType.Example:
-            <div>
+            <div class="locationInput">
                 <select id="places" @onchange="SetExampleLocation">
                     <option value="none" selected hidden>Example Locations</option>
                     <option value="CN87">Seattle, USA</option>

--- a/src/AprsWeatherClient/Pages/Index.razor.cs
+++ b/src/AprsWeatherClient/Pages/Index.razor.cs
@@ -21,7 +21,7 @@ public partial class Index : ComponentBase
     /// <summary>
     /// Output to user in case of errors
     /// </summary>
-    private string userMessage = string.Empty;
+    private string? userMessage;
 
     /// <summary>
     /// The type of location to use, helps determine which
@@ -73,6 +73,7 @@ public partial class Index : ComponentBase
     private Task SetExampleLocation(ChangeEventArgs args)
     {
         userGridsquare = args.Value as string ?? throw new Exception("HTML select object did not have value");
+        userMessage = $"Using gridsquare: {userGridsquare}";
         return SubmitManualLocation();
     }
 
@@ -103,6 +104,7 @@ public partial class Index : ComponentBase
     private async Task UseAutoLocation()
     {
         userGridsquare = null;
+        userMessage = null;
         locationType = LocationType.Device;
 
         GeolocationResult location = await LocationService.GetCurrentPosition();
@@ -117,6 +119,8 @@ public partial class Index : ComponentBase
         userPosition.Coordinates = new GeoCoordinatePortable.GeoCoordinate(location.Position.Coords.Latitude, location.Position.Coords.Longitude);
         userGridsquare = userPosition.EncodeGridsquare(6, false);
 
+        userMessage = $"Detected gridsquare: {userGridsquare}";
+
         await LoadNewReports();
     }
 
@@ -125,6 +129,7 @@ public partial class Index : ComponentBase
     /// </summary>
     private void UseManualLocation()
     {
+        userMessage = null;
         userGridsquare = null;
         locationType = LocationType.Manual;
     }
@@ -134,6 +139,7 @@ public partial class Index : ComponentBase
     /// </summary>
     private void UseExampleLocation()
     {
+        userMessage = null;
         userGridsquare = null;
         locationType = LocationType.Example;
     }
@@ -148,8 +154,6 @@ public partial class Index : ComponentBase
         {
             return;
         }
-
-        userMessage = string.Empty;
 
         // Null checked above in the regex match.
         await ReportList.SetLocation(userGridsquare!);

--- a/src/AprsWeatherClient/Pages/Index.razor.cs
+++ b/src/AprsWeatherClient/Pages/Index.razor.cs
@@ -24,6 +24,12 @@ public partial class Index : ComponentBase
     private string userMessage = string.Empty;
 
     /// <summary>
+    /// The type of location to use, helps determine which
+    /// options to show the user
+    /// </summary>
+    private LocationType locationType = LocationType.Device;
+
+    /// <summary>
     /// Case-insensitive gridsquare of length 4, 6, or 8
     /// </summary>
     private const string GRIDSQUARE_REGEX = @"^[a-zA-Z]{2}[0-9]{2}(([a-zA-Z]{2})|([a-zA-Z]{2}[0-9]{2}))?$";
@@ -67,14 +73,14 @@ public partial class Index : ComponentBase
     private Task SetExampleLocation(ChangeEventArgs args)
     {
         userGridsquare = args.Value as string ?? throw new Exception("HTML select object did not have value");
-        return ManualLocation();
+        return SubmitManualLocation();
     }
 
     /// <summary>
     /// Sets the location using a manual entry value.
     /// </summary>
     /// <returns>The asynchronous task</returns>
-    private Task ManualLocation()
+    private Task SubmitManualLocation()
     {
         if (!Regex.IsMatch(userGridsquare ?? string.Empty, GRIDSQUARE_REGEX))
         {
@@ -90,11 +96,15 @@ public partial class Index : ComponentBase
     }
 
     /// <summary>
-    /// Sets the location using the geolocation API.
+    /// Switch to use a <see cref="LocationType.Device"/> input type.
+    /// Sets the using the geolocation API.
     /// </summary>
     /// <returns>The asynchronous task</returns>
-    private async Task AutoLocation()
+    private async Task UseAutoLocation()
     {
+        userGridsquare = null;
+        locationType = LocationType.Device;
+
         GeolocationResult location = await LocationService.GetCurrentPosition();
 
         if (!location.IsSuccess)
@@ -108,6 +118,24 @@ public partial class Index : ComponentBase
         userGridsquare = userPosition.EncodeGridsquare(6, false);
 
         await LoadNewReports();
+    }
+
+    /// <summary>
+    /// Switch to use a <see cref="LocationType.Manual"/> input type.
+    /// </summary>
+    private void UseManualLocation()
+    {
+        userGridsquare = null;
+        locationType = LocationType.Manual;
+    }
+
+    /// <summary>
+    /// Switch to use a <see cref="LocationType.Example"/> input type.
+    /// </summary>
+    private void UseExampleLocation()
+    {
+        userGridsquare = null;
+        locationType = LocationType.Example;
     }
 
     /// <summary>
@@ -131,5 +159,27 @@ public partial class Index : ComponentBase
     protected override Task OnInitializedAsync()
     {
         return LoadNewReports();
+    }
+
+    /// <summary>
+    /// An enum to keep track of the type of location input
+    /// the user would like to use
+    /// </summary>
+    private enum LocationType
+    {
+        /// <summary>
+        /// Use device location
+        /// </summary>
+        Device,
+
+        /// <summary>
+        /// Manual entry of location
+        /// </summary>
+        Manual,
+
+        /// <summary>
+        /// Use a pre-defined example location
+        /// </summary>
+        Example,
     }
 }

--- a/src/AprsWeatherClient/Pages/Index.razor.cs
+++ b/src/AprsWeatherClient/Pages/Index.razor.cs
@@ -104,7 +104,7 @@ public partial class Index : ComponentBase
     private async Task UseAutoLocation()
     {
         userGridsquare = null;
-        userMessage = null;
+        userMessage = "Detecting location...";
         locationType = LocationType.Device;
 
         GeolocationResult location = await LocationService.GetCurrentPosition();

--- a/src/AprsWeatherClient/Pages/Index.razor.css
+++ b/src/AprsWeatherClient/Pages/Index.razor.css
@@ -1,0 +1,5 @@
+.locationInput {
+    padding: 1em;
+    margin: 1em;
+    border: solid;
+}

--- a/src/AprsWeatherClient/Pages/Index.razor.css
+++ b/src/AprsWeatherClient/Pages/Index.razor.css
@@ -1,5 +1,10 @@
 .locationInput {
     padding: 1em;
     margin: 1em;
-    border: solid;
+    background: linear-gradient(90deg, rgb(5, 39, 103) 0%, #3a0647 70%);
+    border-radius: 0.4em;
+}
+
+.userMessage {
+    color: white;
 }


### PR DESCRIPTION
## Description

Clarify input flow to differentiate between automatic, manual, and example locations.

Due to the re-arranged user input workflow, this will also resolve #30. 

## Changes

* Change weather UI to differentiate flow of inputting a gridsquare, using device location, or using example rather than showing all at once
* New input box that switches based on which context the users chooses. Definitely not a ribbon or anything. :)
* Adds formatting to make the input box prettier!

## Validation

* Validated through local execution using `dotnet run` and `docker compose` options
