### PR TITLE
Increase precision of example gridsquares, add Sydney

### DIFF
--- a/src/AprsWeatherClient/Pages/Index.razor
+++ b/src/AprsWeatherClient/Pages/Index.razor
@@ -37,11 +37,12 @@
             <div class="locationInput">
                 <select id="places" @onchange="SetExampleLocation">
                     <option value="none" selected hidden>Example Locations</option>
-                    <option value="CN87">Seattle, USA</option>
-                    <option value="PM95">Tokyo, Japan</option>
-                    <option value="JF96">Cape Town, South Africa</option>
-                    <option value="GG87">Rio de Janiero, Brazil</option>
-                    <option value="JN18">Paris, France</option>
+                    <option value="CN87uo">Seattle, USA</option>
+                    <option value="PM95vq">Tokyo, Japan</option>
+                    <option value="JF96fb">Cape Town, South Africa</option>
+                    <option value="GG87jc">Rio de Janiero, Brazil</option>
+                    <option value="JN18eu">Paris, France</option>
+                    <option value="QF56od">Sydney, Australia</option>
                 </select>
                 <div class="userMessage">@userMessage</div>
             </div>


### PR DESCRIPTION
## Description

This PR increases the precision of example gridsquares. 4-digit gridsquares would end up placing the "nearest" station some distance from the city in question. Updating to 6-digits will increase the accuracy of results. This change also adds Sydney as an example to cover another continent.

## Changes

* Switch example values to use 6-digit instead of 4-digit gridsquares
* Add Sydney, Australia as an example

## Validation

* Ran locally using docker compose and verified that closest stations were all near the expected locations